### PR TITLE
fix typo error in selector

### DIFF
--- a/addtocalendar.js
+++ b/addtocalendar.js
@@ -312,7 +312,7 @@
                     dom[tagnum].appendChild(atcb_link);
                     dom[tagnum].appendChild(atcb_list);
                 } else {
-                    atcb_link = dom[tagnum].querySelector('atcb-link');
+                    atcb_link = dom[tagnum].querySelector('.atcb-link');
                     atcb_link.parentNode.appendChild(atcb_list);
                     atcb_link.tabIndex = 1;
                     if (atcb_link.id == '') {


### PR DESCRIPTION
Hi,

I fixed a clear typographic error in the query selector when the <a> element already existed. There was a missing "." before the class name.
Thank you for this project !